### PR TITLE
Feature: newest Pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,37 +8,7 @@ matrix:
   include:
     - os: osx
       osx_image: xcode13.4
-      env: VERSION=2.7.11
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.4.4
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.5.1
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.6.0
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.7.0
-
-    - os: linux
-      env: VERSION=2.7
-
-    - os: linux
-      env:
-        - VERSION=2.7
-        - UNICODE_WIDTH=16
-
-    - os: linux
-      env: VERSION=3.5
-
-    - os: linux
-      env: VERSION=3.6
+      env: VERSION=3.7
 
     - os: linux
       env: VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,29 @@ matrix:
     - os: osx
       osx_image: xcode13.4
       env: VERSION=3.7
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.8
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.8
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.10
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.11
 
     - os: linux
       env: VERSION=3.7
+    - os: linux
+      env: VERSION=3.8
+    - os: linux
+      env: VERSION=3.9
+    - os: linux
+      env: VERSION=3.10
+    - os: linux
+      env: VERSION=3.11
 
 install:
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
         - UNICODE_WIDTH=16
 
     - os: linux
-      env: VERSION=3.4
-
-    - os: linux
       env: VERSION=3.5
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,23 @@ services:
 matrix:
   include:
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=2.7.11
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.4.4
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.5.1
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.6.0
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.7.0
 
     - os: linux

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 UNICODE_WIDTH="${UNICODE_WIDTH:-32}"
 
 # Install cmake
-wget --no-check-certificate http://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh
+curl -L https://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh --output cmake-3.2.0-Linux-x86_64.sh
 sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 # Install zlib

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -12,6 +12,9 @@ sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 # Install zlib
 yum install -y zlib-devel
 
+# Install LibLZMA
+yum install -y xz-devel
+
 # taken from https://github.com/matthew-brett/manylinux-builds/blob/master/common_vars.sh
 function lex_ver {
     # Echoes dot-separated version string padded with zeros

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -10,4 +10,5 @@ export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
 
 pip wheel -w dist --verbose ./
 ls dist/*.whl
-pip install dist/*.whl
+# TODO figure out why this is not working when it's not a cross-platform build
+#pip install dist/*.whl

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+# Apparently, Apple moved the path to these in Big Sur, confusing built-in configuration
+export CLANG_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+export LIBRARY_PATH="${CLANG_SYSROOT}/usr/lib"
+export LINK_FLAGS="-isysroot ${CLANG_SYSROOT}"
+export CFLAGS="-isysroot ${CLANG_SYSROOT}"
+export CXXFLAGS="-isysroot ${CLANG_SYSROOT}"
+export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
+
 pip wheel -w dist --verbose ./
 ls dist/*.whl
 pip install dist/*.whl

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -8,7 +8,14 @@ export CFLAGS="-isysroot ${CLANG_SYSROOT}"
 export CXXFLAGS="-isysroot ${CLANG_SYSROOT}"
 export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
 
+# We want to set the minimum target to macOS 11 (~= 10.16, Big Sur)
+# to account for very old Pythons that don't know about anything newer.
+# For example, the default Python 3.7 that this tooling installs is Python 3.7.9
+# and that doesn't understand anything after 10.X. That sets the minimum
+# floor for Python version to 3.7 and macOS verion to 11, but there is good
+# coverage in the original project for anything older: we'll just concentrate on newer.
+export MACOSX_DEPLOYMENT_TARGET=10.16
+
 pip wheel -w dist --verbose ./
 ls dist/*.whl
-# TODO figure out why this is not working when it's not a cross-platform build
-#pip install dist/*.whl
+pip install dist/*.whl

--- a/travis/clean_build.sh
+++ b/travis/clean_build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+find . -type d -name "build" | xargs rm -rf
+rm -rf venv
+rm -rf dist

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+
+# multibuild tooling says "Python should be on the PATH"
 python3 -V
 ln -s /usr/local/bin/python3 /usr/local/bin/python
 export PATH=$PATH:/usr/local/bin
 python -V
-brew update
-brew outdated cmake || brew upgrade cmake
+
+#brew update
+#brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy
 git clone https://github.com/matthew-brett/multibuild
 source multibuild/osx_utils.sh

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -6,8 +6,8 @@ ln -s /usr/local/bin/python3 /usr/local/bin/python
 export PATH=$PATH:/usr/local/bin
 python -V
 
-#brew update
-#brew outdated cmake || brew upgrade cmake
+brew update
+brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy
 git clone https://github.com/matthew-brett/multibuild
 source multibuild/osx_utils.sh

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+python3 -V
+ln -s /usr/local/bin/python3 /usr/local/bin/python
+export PATH=$PATH:/usr/local/bin
+python -V
 brew update
 brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy


### PR DESCRIPTION
This re-expands the multi-version support of the build, but only considers Python versions that are [currently being maintained](https://endoflife.date/python). There is good coverage for older Python version in the original project's build.