### PR TITLE
Bugfix: Python 3.7 hangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,37 +8,7 @@ matrix:
   include:
     - os: osx
       osx_image: xcode13.4
-      env: VERSION=2.7.11
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.4.4
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.5.1
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.6.0
-
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.7.0
-
-    - os: linux
-      env: VERSION=2.7
-
-    - os: linux
-      env:
-        - VERSION=2.7
-        - UNICODE_WIDTH=16
-
-    - os: linux
-      env: VERSION=3.5
-
-    - os: linux
-      env: VERSION=3.6
+      env: VERSION=3.7
 
     - os: linux
       env: VERSION=3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then source travis/build_linux.sh; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then source travis/build_osx.sh; fi
 
-deploy:
-  provider: releases
-  api_key:
-    secure: FBmxUWVS+JJJTYBXZdDKEQX0zvdjXwor1nhYFas9DAwoq5Z2PllV610arqjP2vdmJdsQTNv6/sGswf36tfCwERDOqFnZE4Dh0MlhUVIBzMdDBiA2I/5n+r0MCbkQPO9ZdPVY9JCNIx6mUIH0k/dcJac4ADEeOq6ANk8APhL+f8aqwr0a7Fo82qKqBXbqDXoW74R6jxRS/Jiba/jD4VsIeVlWszIAiSk9/UE8MGOPt4zvfsg+sW3XOqfckO+jfFJIJXTB+wIbc8RwUP4Qrgh+1vUFCVtq52Bxf+8eKJxCJOpLpGOjUaIfzL9BbKKuDP84g3YxAEEv5MK/6eZEmqtH1OCNIx8x9i1f22lhtVBxhRlqSKNrNzFooWbXE+IUF34Xkbcq3LzkAm4MJVP1cq5+JEm2dOBh1FzUhYGCEPeRM59S6geVX5whUGSP+zrp7ZVq0lRmaZQd9Z+9BWZGSDO3Y3ApmVArDcfT8jboTZ0/gHHEoKpy6th7DcwcPcXg1rUihRf3lRRwWTwG2rLMqeddlurXXELzrPmKvCPwZKREZw6gNd1J5URFtbYfXXcOvAzPpLvN7EJopQO8G/roogh5QcpNFbf871LPNhymI8jasYVlsujR/aFx0KJbcmK9m6gAzhljbPwaldJig0YR00jDNd2/zfn8l3VTcIPKH71SkFY=
-  file: dist/*.whl
-  file_glob: true
-  skip_cleanup: true
-  on:
-    tags: true
-    repo: meta-toolkit/metapy
+# deploy:
+#   provider: releases
+#   api_key:
+#     secure: FBmxUWVS+JJJTYBXZdDKEQX0zvdjXwor1nhYFas9DAwoq5Z2PllV610arqjP2vdmJdsQTNv6/sGswf36tfCwERDOqFnZE4Dh0MlhUVIBzMdDBiA2I/5n+r0MCbkQPO9ZdPVY9JCNIx6mUIH0k/dcJac4ADEeOq6ANk8APhL+f8aqwr0a7Fo82qKqBXbqDXoW74R6jxRS/Jiba/jD4VsIeVlWszIAiSk9/UE8MGOPt4zvfsg+sW3XOqfckO+jfFJIJXTB+wIbc8RwUP4Qrgh+1vUFCVtq52Bxf+8eKJxCJOpLpGOjUaIfzL9BbKKuDP84g3YxAEEv5MK/6eZEmqtH1OCNIx8x9i1f22lhtVBxhRlqSKNrNzFooWbXE+IUF34Xkbcq3LzkAm4MJVP1cq5+JEm2dOBh1FzUhYGCEPeRM59S6geVX5whUGSP+zrp7ZVq0lRmaZQd9Z+9BWZGSDO3Y3ApmVArDcfT8jboTZ0/gHHEoKpy6th7DcwcPcXg1rUihRf3lRRwWTwG2rLMqeddlurXXELzrPmKvCPwZKREZw6gNd1J5URFtbYfXXcOvAzPpLvN7EJopQO8G/roogh5QcpNFbf871LPNhymI8jasYVlsujR/aFx0KJbcmK9m6gAzhljbPwaldJig0YR00jDNd2/zfn8l3VTcIPKH71SkFY=
+#   file: dist/*.whl
+#   file_glob: true
+#   skip_cleanup: true
+#   on:
+#     tags: true
+#     repo: meta-toolkit/metapy

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
         - UNICODE_WIDTH=16
 
     - os: linux
-      env: VERSION=3.4
-
-    - os: linux
       env: VERSION=3.5
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,29 @@ matrix:
     - os: osx
       osx_image: xcode13.4
       env: VERSION=3.7
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.8
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.9
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.10
+    - os: osx
+      osx_image: xcode13.4
+      env: VERSION=3.11
 
     - os: linux
       env: VERSION=3.7
+    - os: linux
+      env: VERSION=3.8
+    - os: linux
+      env: VERSION=3.9
+    - os: linux
+      env: VERSION=3.10
+    - os: linux
+      env: VERSION=3.11
 
 install:
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
       env: VERSION=3.9
     - os: linux
       env: VERSION=3.10
-    - os: linux
-      env: VERSION=3.11
 
 install:
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,23 @@ services:
 matrix:
   include:
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=2.7.11
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.4.4
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.5.1
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.6.0
 
     - os: osx
+      osx_image: xcode13.4
       env: VERSION=3.7.0
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
     - os: osx
       osx_image: xcode13.4
       env: VERSION=3.10
-    - os: osx
-      osx_image: xcode13.4
-      env: VERSION=3.11
 
     - os: linux
       env: VERSION=3.7

--- a/include/metapy_identifiers.h
+++ b/include/metapy_identifiers.h
@@ -24,7 +24,7 @@ struct identifier_caster
     using underlying_type = typename Type::underlying_type;
     using type_conv = make_caster<underlying_type>;
 
-    PYBIND11_TYPE_CASTER(Type, _("id[") + type_conv::name() + _("]"));
+    PYBIND11_TYPE_CASTER(Type, _("id[") + type_conv::name + _("]"));
 
     bool load(handle src, bool convert)
     {

--- a/include/metapy_index.h
+++ b/include/metapy_index.h
@@ -56,10 +56,7 @@ struct type_caster<meta::index::search_result>
         return result.release();
     }
 
-    static PYBIND11_DESCR name()
-    {
-        return type_descr(_("SearchResult"));
-    }
+    static constexpr auto name = _("SearchResult");
 
     static handle cast(const meta::index::search_result* sr,
                        return_value_policy policy, handle parent)

--- a/include/metapy_probe_map.h
+++ b/include/metapy_probe_map.h
@@ -62,8 +62,8 @@ struct probe_map_caster
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name() + _(", ")
-                                   + value_conv::name() + _(">"));
+    PYBIND11_TYPE_CASTER(type, _("dict<") + key_conv::name + _(", ")
+                                   + value_conv::name + _(">"));
 };
 
 template <class Key, class Value, class ProbingStrategy, class Hash,

--- a/src/metapy_embeddings.cpp
+++ b/src/metapy_embeddings.cpp
@@ -41,7 +41,7 @@ void metapy_bind_embeddings(py::module& m)
                     query,
                 std::size_t k) {
                  util::array_view<const double> avquery{query.data(),
-                                                        query.size()};
+                                                        static_cast<std::size_t>(query.size())};
                  auto scores = self.top_k(avquery, k);
 
                  std::vector<py::tuple> result;

--- a/travis/build_linux.sh
+++ b/travis/build_linux.sh
@@ -3,4 +3,4 @@ sudo docker run --rm \
     -e PYTHON_VERSION=$VERSION \
     -e UNICODE_WIDTH=$UNICODE_WIDTH \
     -v `pwd`:/metapy \
-    quay.io/pypa/manylinux_2_28_x86_64 /metapy/travis/build_linux_wheel.sh
+    quay.io/pypa/manylinux_2_24_x86_64 /metapy/travis/build_linux_wheel.sh

--- a/travis/build_linux.sh
+++ b/travis/build_linux.sh
@@ -3,4 +3,4 @@ sudo docker run --rm \
     -e PYTHON_VERSION=$VERSION \
     -e UNICODE_WIDTH=$UNICODE_WIDTH \
     -v `pwd`:/metapy \
-    quay.io/pypa/manylinux1_x86_64 /metapy/travis/build_linux_wheel.sh
+    quay.io/pypa/manylinux_2_28_x86_64 /metapy/travis/build_linux_wheel.sh

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -30,7 +30,7 @@ function strip_dots {
     echo $1 | sed "s/\.//g"
 }
 
-# taken from https://github.com/matthew-brett/manylinux-builds/blob/master/common_vars.sh
+# taken from https://github.com/matthew-brett/multibuild/blob/24d35a4af2583473a0ec224dbe1990dd1e0ace5d/manylinux_utils.sh#L15
 function cpython_path {
     # Return path to cpython given
     # * version (of form "2.7")
@@ -38,20 +38,26 @@ function cpython_path {
     #
     # For back-compatibility "u" as u_width also means "32"
     local py_ver="${1:-2.7}"
+    local abi_suff=m
     local u_width="${2:-${UNICODE_WIDTH}}"
     local u_suff=u
+    # Python 3.8 and up no longer uses the PYMALLOC 'm' suffix
+    # https://github.com/pypa/wheel/pull/303
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.8) ]; then
+        abi_suff=""
+    fi
     # Back-compatibility
     if [ "$u_width" == "u" ]; then u_width=32; fi
-    # For Python >= 3.3, "u" suffix not meaningful
-    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.3) ] ||
+    # For Python >= 3.4, "u" suffix not meaningful
+    if [ $(lex_ver $py_ver) -ge $(lex_ver 3.4) ] ||
         [ "$u_width" == "16" ]; then
         u_suff=""
     elif [ "$u_width" != "32" ]; then
         echo "Incorrect u_width value $u_width"
-        # exit 1
+        exit 1
     fi
-    local no_dots=$(strip_dots $py_ver)
-    echo "/opt/python/cp${no_dots}-cp${no_dots}m${u_suff}"
+    local no_dots=$(echo $py_ver | tr -d .)
+    echo "/opt/python/cp${no_dots}-cp${no_dots}$abi_suff${u_suff}"
 }
 
 # taken from https://github.com/matthew-brett/manylinux-builds/blob/master/common_vars.sh

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 UNICODE_WIDTH="${UNICODE_WIDTH:-32}"
 
 # Install cmake
-wget --no-check-certificate http://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh
+curl -L https://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh --output cmake-3.2.0-Linux-x86_64.sh
 sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 # Install zlib

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -10,10 +10,10 @@ curl -L https://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-x86_64.sh --output cm
 sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 # Install zlib
-yum install -y zlib-devel
+apt install -y zlib1g-dev
 
 # Install LibLZMA
-yum install -y xz-devel
+apt install -y liblzma5
 
 # taken from https://github.com/matthew-brett/manylinux-builds/blob/master/common_vars.sh
 function lex_ver {

--- a/travis/build_linux_wheel.sh
+++ b/travis/build_linux_wheel.sh
@@ -12,6 +12,9 @@ sh cmake-3.2.0-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 # Install zlib
 yum install -y zlib-devel
 
+# Install LibLZMA
+yum install -y xz-devel
+
 # taken from https://github.com/matthew-brett/manylinux-builds/blob/master/common_vars.sh
 function lex_ver {
     # Echoes dot-separated version string padded with zeros

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -10,4 +10,5 @@ export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
 
 pip wheel -w dist --verbose ./
 ls dist/*.whl
-pip install dist/*.whl
+# TODO figure out why this is not working when it's not a cross-platform build
+#pip install dist/*.whl

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+# Apparently, Apple moved the path to these in Big Sur, confusing built-in configuration
+export CLANG_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+export LIBRARY_PATH="${CLANG_SYSROOT}/usr/lib"
+export LINK_FLAGS="-isysroot ${CLANG_SYSROOT}"
+export CFLAGS="-isysroot ${CLANG_SYSROOT}"
+export CXXFLAGS="-isysroot ${CLANG_SYSROOT}"
+export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
+
 pip wheel -w dist --verbose ./
 ls dist/*.whl
 pip install dist/*.whl

--- a/travis/build_osx.sh
+++ b/travis/build_osx.sh
@@ -8,7 +8,14 @@ export CFLAGS="-isysroot ${CLANG_SYSROOT}"
 export CXXFLAGS="-isysroot ${CLANG_SYSROOT}"
 export CPPFLAGS="-isysroot ${CLANG_SYSROOT}"
 
+# We want to set the minimum target to macOS 11 (~= 10.16, Big Sur)
+# to account for very old Pythons that don't know about anything newer.
+# For example, the default Python 3.7 that this tooling installs is Python 3.7.9
+# and that doesn't understand anything after 10.X. That sets the minimum
+# floor for Python version to 3.7 and macOS verion to 11, but there is good
+# coverage in the original project for anything older: we'll just concentrate on newer.
+export MACOSX_DEPLOYMENT_TARGET=10.16
+
 pip wheel -w dist --verbose ./
 ls dist/*.whl
-# TODO figure out why this is not working when it's not a cross-platform build
-#pip install dist/*.whl
+pip install dist/*.whl

--- a/travis/clean_build.sh
+++ b/travis/clean_build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-find . -type d -name "build" | xargs rm -rf
-rm -rf venv
-rm -rf dist

--- a/travis/clean_build.sh
+++ b/travis/clean_build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+find . -type d -name "build" | xargs rm -rf
+rm -rf venv
+rm -rf dist

--- a/travis/install_linux.sh
+++ b/travis/install_linux.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo docker pull quay.io/pypa/manylinux1_x86_64
+sudo docker pull quay.io/pypa/manylinux_2_28_x86_64

--- a/travis/install_linux.sh
+++ b/travis/install_linux.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo docker pull quay.io/pypa/manylinux_2_28_x86_64
+sudo docker pull quay.io/pypa/manylinux_2_24_x86_64

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
+
+# multibuild tooling says "Python should be on the PATH"
 python3 -V
 ln -s /usr/local/bin/python3 /usr/local/bin/python
 export PATH=$PATH:/usr/local/bin
 python -V
-brew update
-brew outdated cmake || brew upgrade cmake
+
+#brew update
+#brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy
 git clone https://github.com/matthew-brett/multibuild
 source multibuild/osx_utils.sh

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -6,8 +6,8 @@ ln -s /usr/local/bin/python3 /usr/local/bin/python
 export PATH=$PATH:/usr/local/bin
 python -V
 
-#brew update
-#brew outdated cmake || brew upgrade cmake
+brew update
+brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy
 git clone https://github.com/matthew-brett/multibuild
 source multibuild/osx_utils.sh

--- a/travis/install_osx.sh
+++ b/travis/install_osx.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+python3 -V
+ln -s /usr/local/bin/python3 /usr/local/bin/python
+export PATH=$PATH:/usr/local/bin
+python -V
 brew update
 brew outdated cmake || brew upgrade cmake
 git clone --recursive https://github.com/MacPython/terryfy


### PR DESCRIPTION
The root cause of this defect, which exists on Python 3.7 in the original project, and also on all subsequent versions in our fork, was [this pybind11 defect](https://github.com/pybind/pybind11/issues/1473) related to the move from [TLS to TSS in Python 3.7](https://peps.python.org/pep-0539/). Because the symptoms of the misbehaving software looked very much like GIL mismanagement when examining the system calls (stuck in a tight polling loop, presumable in deadlock), it was easy to make the connection with the above defect and try the proposed solution, which was to upgrade to `pybind11` version 2.3 or higher. Another hint of where to look came from a other projects reporting similar issues on Github, and pointing to the root cause issue (e.g.: [pytorch #11419](https://github.com/pytorch/pytorch/issues/11419)).